### PR TITLE
Throw ParseError if encountered

### DIFF
--- a/canonix/exe/Main.hs
+++ b/canonix/exe/Main.hs
@@ -32,11 +32,11 @@ parser =
 
 runPipe :: Bool -> IO ()
 runPipe debug = do
-  BL.putStr =<< format debug =<< BS.getContents
+  BL.putStr =<< format debug "<stdin>" =<< BS.getContents
 
 runInPlace :: [FilePath] -> Bool -> IO ()
 runInPlace paths debug = do
   when (null paths) $ do
     hPutStrLn stderr "No file arguments provided. Did you mean --pipe?"
-  forConcurrently_ paths $ \path ->
-    BL.writeFile path =<< format debug =<< BS.readFile path
+  forConcurrently_ paths $ \filepath ->
+    BL.writeFile filepath =<< format debug filepath =<< BS.readFile filepath

--- a/canonix/src/Canonix/Monad/CnxFmt.hs
+++ b/canonix/src/Canonix/Monad/CnxFmt.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
-module Canonix.Monad.CnxFmt 
+module Canonix.Monad.CnxFmt
   ( -- * CnxFmt monad
     CnxFmt
   , ErrorMessage
@@ -33,11 +33,12 @@ module Canonix.Monad.CnxFmt
   , newline
   , emptyLine
   , finalNewline
+  , throw
 
   , withIndent
   , withIndent'
   , withOptionalIndent
-  
+
   , preserveEmptyLinesBefore
   , trySingleLine
   , forceMultiline

--- a/canonix/src/Canonix/TreeSitter.hs
+++ b/canonix/src/Canonix/TreeSitter.hs
@@ -15,6 +15,7 @@ import           Foreign.Marshal.Array          ( peekArray
                                                 )
 import           Foreign.Marshal.Utils          ( with )
 import           System.IO
+import           TreeSitter.Symbol              ( fromTSSymbol )
 import           TreeSitter.Nix
 import           TreeSitter.Node         hiding ( Node )
 import qualified TreeSitter.Node               as TS
@@ -46,7 +47,7 @@ printNode ind source n@TS.Node {..} = do
         let TSPoint {..} = nodeEndPoint
         in  "(" ++ show pointRow ++ "," ++ show pointColumn ++ ")"
       typ :: Grammar
-      typ = toEnum $ fromEnum $ nodeSymbol
+      typ = fromTSSymbol nodeSymbol
   hPutStrLn stderr $ replicate (ind * 2) ' ' ++ show typ ++ start ++ "-" ++ end
   hPutStrLn stderr $ replicate (ind * 2) ' ' ++ show (nodeInner source n)
 
@@ -60,7 +61,7 @@ dump source i nd = do
   void $ forChildren nd $ \c -> dump source (i + 1) c
 
 abstract :: TS.Node -> Node
-abstract n = Node { typ       = toEnum (fromEnum (nodeSymbol n))
+abstract n = Node { typ       = fromTSSymbol $ nodeSymbol n
                   , startByte = fromIntegral $ nodeStartByte n
                   , endByte   = fromIntegral $ nodeEndByte n
                   , startRow  = fromIntegral $ pointRow $ nodeStartPoint n

--- a/canonix/tests/Main.hs
+++ b/canonix/tests/Main.hs
@@ -22,7 +22,7 @@ main = do
         t
 
 describeGoldenTests
-  :: FilePath -> (BS.ByteString -> IO BL.ByteString) -> IO Spec
+  :: FilePath -> (FilePath -> BS.ByteString -> IO BL.ByteString) -> IO Spec
 describeGoldenTests dir f = do
   files <- filter (".input.nix" `isSuffixOf`) <$> listDirectory dir
   pure $ do
@@ -33,6 +33,6 @@ describeGoldenTests dir f = do
           outputFile = basename <> ".output.nix"
       it basename $ do
         input    <- BS.readFile (dir <> file)
-        output   <- f input
+        output   <- f (dir <> file) input
         expected <- BL.readFile (dir <> outputFile)
         output `shouldBe` expected

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,11 +14,11 @@ let
         hsuper.callCabal2nix "canonix" (self.gitignoreSource ../canonix) {};
       # TODO: remove dontCheck: test compile error: No instance for (Control.Monad.Fail.MonadFail (PropertyT IO))
       tree-sitter =
-        hsuper.callCabal2nix "tree-sitter" haskell-tree-sitterSource {
+        hsuper.callCabal2nix "tree-sitter" (haskell-tree-sitterSource + "/tree-sitter") {
           hedgehog =  hsuper.callCabal2nix "hedgehog" (sources.haskell-hedgehog + "/hedgehog") {};
         };
       tree-sitter-nix =
-        hsuper.callCabal2nix "tree-sitter-nix" (haskell-tree-sitterSource + "/languages/nix") {};
+        hsuper.callCabal2nix "tree-sitter-nix" (haskell-tree-sitterSource + "/tree-sitter-nix") {};
       fused-effects =
          # hsuper.callHackage "fused-effects" "0.4.0.0" {};
          # not in nixpkgs' hackage metadata yet

--- a/nix/src/haskell-tree-sitter.nix
+++ b/nix/src/haskell-tree-sitter.nix
@@ -1,6 +1,6 @@
 # needed to fetch submodules
 { fetchgit }: fetchgit {
-  url = https://github.com/domenkozar/haskell-tree-sitter.git;
-  rev = "01270dcd45e1f45e323bcfcd8015b4a47a0cbb37";
-  sha256 = "sha256:0y8mcicijdp3f0jxz2yg6z6gg7bp9pxvqzy06cg6lskryakiz61v";
+  url = https://github.com/tree-sitter/haskell-tree-sitter.git;
+  rev = "a2b6079c51afbfd412b16e4f11ae98d66506e8b7";
+  sha256 = "09njdx5znkpz6dfl2fv8630xllh30gwb40x7sy54qiqi1155y1qi";
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,9 +2,9 @@ resolver: lts-13.25
 packages:
 - canonix
 # TODO: automate cloning it from niv
-- location: haskell-tree-sitter
+- location: haskell-tree-sitter/tree-sitter
   extra-dep: true
-- location: haskell-tree-sitter/languages/nix
+- location: haskell-tree-sitter/tree-sitter-nix
   extra-dep: true
 extra-deps:
 - fused-effects-0.4.0.0


### PR DESCRIPTION
We should probably write to a temp file and swap the final result once it's all done.

Otherwise if error is thrown, formatted file might chopped off?